### PR TITLE
Remove Dependabot npm group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,3 @@ updates:
       - dependency-name: '*'
         update-types:
           - version-update:semver-major
-    groups:
-      minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - patch
-          - minor


### PR DESCRIPTION
## Summary
- remove `groups` configuration from `.github/dependabot.yml`
- keep only the global ignore rule for `version-update:semver-major`
- revert to per-dependency Dependabot PRs to avoid grouped-update major-version leakage

## Background
- We observed Dependabot PR #64 (minor-and-patch group) still included semver-major updates such as `@types/express` (4 -> 5).
- Current Dependabot behavior with grouped updates may not always respect `ignore.update-types: version-update:semver-major` as expected.
- To prioritize predictable update behavior, this PR disables grouping and falls back to per-dependency PRs.

## Test plan
- [x] Confirm `.github/dependabot.yml` has no `groups` section
- [x] Confirm `ignore` for `version-update:semver-major` remains
- [ ] Wait for next Dependabot run and verify major updates are no longer grouped into minor/patch PRs