### PR TITLE
chore: adjust dependabot cooldown and node engine requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 0
+      semver-patch-days: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "nar_api",
   "version": "0.1.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
   },
   "bin": {
     "nar_api": "bin/nar_api.js"


### PR DESCRIPTION
## Summary
- switch Dependabot from major-version ignore to cooldown-based update timing
- cap open Dependabot PR count and keep minor/patch updates immediate
- align `engines` in package manifests with Node 22 and npm 10 requirements

## Test plan
- [x] Verify `.github/dependabot.yml` reflects cooldown policy
- [x] Verify `package.json` and `package-lock.json` engine fields are synchronized
- [ ] Confirm GitHub Actions CI passes

Made with [Cursor](https://cursor.com)