### PR TITLE
ci: npm を packageManager + Corepack で 10.9.4 に固定

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           fetch-depth: 0 
       - uses: asdf-vm/actions/install@v4
+      - name: Enable Corepack (pin npm to packageManager)
+        run: corepack enable
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "nar_api",
   "version": "0.1.0",
+  "packageManager": "npm@10.9.4",
   "engines": {
     "node": ">=22.0.0",
-    "npm": ">=10.0.0"
+    "npm": ">=10.9.4"
   },
   "bin": {
     "nar_api": "bin/nar_api.js"


### PR DESCRIPTION
## 目的
Dependabot の PR で `npm ci` が落ちる問題に対し、**npm のバージョンをリポジトリで明示**し、CI でも同じ npm を使うようにします。

## 変更
- `package.json` に `"packageManager": "npm@10.9.4"`（`.tool-versions` の Node 22.21.1 に同梱される npm と一致）
- `engines.npm` を `>=10.9.4` に更新
- GitHub Actions で `asdf` インストール直後に `corepack enable` を実行（`npm ci` / 以降の `npm` が `packageManager` に従う）

## 補足
- ローカルでも初回だけ `corepack enable` を実行すると、同じ npm に揃えやすくなります（任意）。
- `package-lock.json` は `packageManager` 追加のみでは変更不要でした。

## 確認
- ローカルで `npm ci` / `npm run test` 成功済み

Made with [Cursor](https://cursor.com)