### PR TITLE
test(api): Express 5 の raceid パラメータ絞り込み分岐のテスト追加

### DIFF
--- a/functions/api.ts
+++ b/functions/api.ts
@@ -7,6 +7,11 @@ import { getRace } from './api_get_race'
 const app = express()
 app.disable('x-powered-by')
 
+/** @types/express 5 では route param が string 以外になり得るための絞り込み */
+export function raceidRouteParamIsString (value: unknown): value is string {
+  return typeof value === 'string'
+}
+
 function asyncWrapper (
   fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
 ) {
@@ -42,29 +47,34 @@ app.get(
   })
 )
 
+export async function handleGetRaceRequest (
+  req: Request,
+  res: Response
+): Promise<void> {
+  const raceidParam = req.params.raceid
+  if (!raceidRouteParamIsString(raceidParam)) {
+    res.status(400).send('Bad raceid parameter')
+    return
+  }
+  const raceid = raceidParam
+
+  if (raceid.length !== 12) {
+    res.status(400).send('Bad raceid parameter')
+    return
+  }
+
+  if (!DateTime.fromISO(raceid.slice(0, 8)).isValid) {
+    res.status(400).send('Bad raceid parameter')
+    return
+  }
+
+  const race = await getRace(raceid)
+  res.json(race)
+}
+
 app.get(
   '/races/:raceid',
-  asyncWrapper(async (req, res) => {
-    const raceidParam = req.params.raceid
-    if (typeof raceidParam !== 'string') {
-      res.status(400).send('Bad raceid parameter')
-      return
-    }
-    const raceid = raceidParam
-
-    if (raceid.length !== 12) {
-      res.status(400).send('Bad raceid parameter')
-      return
-    }
-
-    if (!DateTime.fromISO(raceid.slice(0, 8)).isValid) {
-      res.status(400).send('Bad raceid parameter')
-      return
-    }
-
-    const race = await getRace(raceid)
-    res.json(race)
-  })
+  asyncWrapper(handleGetRaceRequest)
 )
 
 app.all('/:wildcard', (req, res) => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,9 @@
+import type { Request, Response } from 'express'
 import request from 'supertest'
-import app from '../functions/api'
+import app, {
+  handleGetRaceRequest,
+  raceidRouteParamIsString,
+} from '../functions/api'
 import { getRaceIds } from '../functions/api_get_raceids'
 import { getRace } from '../functions/api_get_race'
 
@@ -10,6 +14,24 @@ vitest.mock('../functions/api_get_race')
 
 const mockGetRaceIds = vitest.mocked(getRaceIds)
 const mockGetRace = vitest.mocked(getRace)
+
+describe('raceidRouteParamIsString', () => {
+  it('文字列なら true', () => {
+    expect(raceidRouteParamIsString('202401020304')).toBe(true)
+  })
+
+  it('配列なら false（@types/express 5 で params が string[] になり得るための分岐）', () => {
+    expect(raceidRouteParamIsString(['202401020304'])).toBe(false)
+  })
+
+  it('undefined なら false', () => {
+    expect(raceidRouteParamIsString(undefined)).toBe(false)
+  })
+
+  it('数値なら false', () => {
+    expect(raceidRouteParamIsString(202401020304)).toBe(false)
+  })
+})
 
 describe('api', () => {
   afterEach(() => {
@@ -111,6 +133,21 @@ describe('api', () => {
     })
     const result = await request(app).get('/races/202401400304')
     expect(result.status).toBe(400)
+  })
+
+  it('/races: raceid が文字列でないとき handleGetRaceRequest が 400', async () => {
+    const send = vitest.fn()
+    const status = vitest.fn().mockReturnValue({ send })
+    const req = {
+      params: { raceid: ['202401020304'] },
+    } as unknown as Request
+    const res = { status, send } as unknown as Response
+
+    await handleGetRaceRequest(req, res)
+
+    expect(status).toHaveBeenCalledWith(400)
+    expect(send).toHaveBeenCalledWith('Bad raceid parameter')
+    expect(mockGetRace).not.toHaveBeenCalled()
   })
 
   it('存在しないURL', async () => {


### PR DESCRIPTION
## 概要

コミット `9dc584b` で追加した `req.params.raceid` が文字列でない場合の 400 応答分岐に対するテストがなかったため、カバレッジと回 regressions を追加しました。

## 変更内容

- `raceidRouteParamIsString` をエクスポートし、文字列／配列／`undefined`／数値に対する単体テストを追加（`@types/express 5` で params が string 以外になり得る前提）。
- `/races/:raceid` の処理を `handleGetRaceRequest` に抽出し、`params.raceid` が配列のケースをモックして 400 応答と `getRace` 非呼び出しを検証。

## 確認

- `npm test` 通過
- `api.ts` 当該分岐を含めカバレッジで実行可能

Made with [Cursor](https://cursor.com)