### PR TITLE
chore(ci): Dependabot で @aws-lambda-powertools をグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       semver-major-days: 7
       semver-minor-days: 0
       semver-patch-days: 0
+    groups:
+      aws-lambda-powertools:
+        patterns:
+          - "@aws-lambda-powertools/*"


### PR DESCRIPTION
## 概要

Dependabot の npm 更新で `@aws-lambda-powertools/*` を同一 PR にまとめるグループを追加しました。

## 背景

Powertools の各パッケージは `@aws-lambda-powertools/commons` に依存しており、tracer だけが先に上がると logger と commons の API がずれ、CDK の esbuild バンドルが失敗することがあります（例: PR #75）。

## 変更内容

- `.github/dependabot.yml` の npm 更新に `groups.aws-lambda-powertools` を追加（パターン: `@aws-lambda-powertools/*`）


Made with [Cursor](https://cursor.com)