### PR TITLE
ci: build-and-deploy の GitHub Actions 警告を解消

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -15,14 +15,14 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 
+          fetch-depth: 0
       - uses: asdf-vm/actions/install@v4
       - name: Enable Corepack (pin npm to packageManager)
         run: corepack enable
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ap-northeast-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -37,10 +37,10 @@ jobs:
       - name: Test
         run: npm run test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Deploy
         if: startsWith(github.ref, 'refs/heads/main')
         run: npm run deploy


### PR DESCRIPTION
## 概要

- GitHub が非推奨としている Node.js 20 ベースのアクションへの警告を、`actions/checkout` と `configure-aws-credentials` を Node 24 対応のメジャーバージョンへ更新して解消する。
- Sonar の「GPG 署名検証をスキップ」警告を、`sonarqube-scan-action` v8（検証既定 `false` で有効）へ更新して解消する。
- Sonar ステップの `env` インデントを修正し、`fetch-depth` 行末の空白を除去する。

## テスト計画

- [x] 本 PR の `build-and-deploy` ワークフローが成功することを確認する。
- [x] ログに Node 20 非推奨および Sonar の GPG スキップ警告が出ていないことを確認する。

Made with [Cursor](https://cursor.com)