### PR TITLE
プロジェクトを ESM 化し @middy/core v7 に対応する

### DIFF
--- a/bin/nar_api.ts
+++ b/bin/nar_api.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import 'source-map-support/register'
 import * as cdk from 'aws-cdk-lib'
-import { NarApiStack } from '../lib/nar_api-stack'
+import { NarApiStack } from '../lib/nar_api-stack.js'
 
 const app = new cdk.App()
 const stackName = app.node.tryGetContext('stackName')

--- a/cdk.json
+++ b/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/nar_api.ts",
+  "app": "node --enable-source-maps build/bin/nar_api.js",
   "watch": {
     "include": [
       "**"

--- a/functions/api.ts
+++ b/functions/api.ts
@@ -1,8 +1,8 @@
 import express, { Request, Response, NextFunction } from 'express'
 import { DateTime } from 'luxon'
-import * as Log from './common/log'
-import { getRaceIds } from './api_get_raceids'
-import { getRace } from './api_get_race'
+import * as Log from './common/log.js'
+import { getRaceIds } from './api_get_raceids.js'
+import { getRace } from './api_get_race.js'
 
 const app = express()
 app.disable('x-powered-by')

--- a/functions/api_get_race.ts
+++ b/functions/api_get_race.ts
@@ -3,9 +3,9 @@ import { pipeline } from 'node:stream/promises'
 import { createGunzip } from 'node:zlib'
 import { DateTime } from 'luxon'
 import * as cheerio from 'cheerio'
-import { getRaceDatePrefix } from './common/get_race_date_prefix'
-import { getEnvironment } from './common/get_environment'
-import { getObject as S3GetObject } from './common/awss3'
+import { getRaceDatePrefix } from './common/get_race_date_prefix.js'
+import { getEnvironment } from './common/get_environment.js'
+import { getObject as S3GetObject } from './common/awss3.js'
 
 const placeMap = new Map<string, string>([
   ['03', '帯広'],

--- a/functions/api_get_raceids.ts
+++ b/functions/api_get_raceids.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
-import { listObjects as S3ListObjects } from './common/awss3'
-import { getEnvironment } from './common/get_environment'
-import { getRaceDatePrefix } from './common/get_race_date_prefix'
+import { listObjects as S3ListObjects } from './common/awss3.js'
+import { getEnvironment } from './common/get_environment.js'
+import { getRaceDatePrefix } from './common/get_race_date_prefix.js'
 
 type ReturnType = {
   date: string;

--- a/functions/api_handler.ts
+++ b/functions/api_handler.ts
@@ -1,10 +1,10 @@
-import serverlessExpress from '@codegenie/serverless-express'
+import { configure as serverlessExpress } from '@codegenie/serverless-express'
 import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware'
 import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware'
 import middy from '@middy/core'
-import app from './api'
-import * as Log from './common/log'
-import { getLogger, getTracer } from './common/powertools'
+import app from './api.js'
+import * as Log from './common/log.js'
+import { getLogger, getTracer } from './common/powertools.js'
 
 const logger = getLogger('INFO')
 const tracer = getTracer()

--- a/functions/common/awss3.ts
+++ b/functions/common/awss3.ts
@@ -6,7 +6,7 @@ import {
   StorageClass,
 } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
-import { getTracer } from './powertools'
+import { getTracer } from './powertools.js'
 
 const tracer = getTracer()
 const client = tracer.captureAWSv3Client(new S3Client({}))

--- a/functions/common/awssfn.ts
+++ b/functions/common/awssfn.ts
@@ -1,5 +1,5 @@
 import { SFNClient, StartSyncExecutionCommand } from '@aws-sdk/client-sfn'
-import { getTracer } from './powertools'
+import { getTracer } from './powertools.js'
 
 const tracer = getTracer()
 const client = tracer.captureAWSv3Client(new SFNClient())

--- a/functions/common/get_race_date_prefix.ts
+++ b/functions/common/get_race_date_prefix.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { getEnvironment } from './get_environment'
+import { getEnvironment } from './get_environment.js'
 
 export function getRaceDatePrefix (date: DateTime): string {
   const cachePrefix = getEnvironment('CACHE_PREFIX')

--- a/functions/get_dayraces_urls.ts
+++ b/functions/get_dayraces_urls.ts
@@ -6,9 +6,9 @@ import axios from 'axios'
 import middy from '@middy/core'
 import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware'
 import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware'
-import { isObject, isString } from './common/type_utils'
-import { getLogger, getTracer } from './common/powertools'
-import { chunk } from './common/array_utils'
+import { isObject, isString } from './common/type_utils.js'
+import { getLogger, getTracer } from './common/powertools.js'
+import { chunk } from './common/array_utils.js'
 
 const logger = getLogger('INFO')
 const tracer = getTracer()

--- a/functions/get_race.ts
+++ b/functions/get_race.ts
@@ -11,10 +11,10 @@ import type { SQSBatchResponse, SQSEvent } from 'aws-lambda'
 import middy from '@middy/core'
 import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware'
 import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware'
-import { getLogger, getTracer } from './common/powertools'
-import * as awsS3 from './common/awss3'
-import { getEnvironment } from './common/get_environment'
-import { getRaceDatePrefix } from './common/get_race_date_prefix'
+import { getLogger, getTracer } from './common/powertools.js'
+import * as awsS3 from './common/awss3.js'
+import { getEnvironment } from './common/get_environment.js'
+import { getRaceDatePrefix } from './common/get_race_date_prefix.js'
 
 const logger = getLogger('INFO')
 const tracer = getTracer()

--- a/functions/get_race_urls.ts
+++ b/functions/get_race_urls.ts
@@ -5,9 +5,9 @@ import axios, { AxiosResponse } from 'axios'
 import middy from '@middy/core'
 import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware'
 import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware'
-import { isObject, isString } from './common/type_utils'
-import { getLogger, getTracer } from './common/powertools'
-import { chunk } from './common/array_utils'
+import { isObject, isString } from './common/type_utils.js'
+import { getLogger, getTracer } from './common/powertools.js'
+import { chunk } from './common/array_utils.js'
 
 const logger = getLogger('INFO')
 const tracer = getTracer()

--- a/functions/sqs_to_statemachine.ts
+++ b/functions/sqs_to_statemachine.ts
@@ -2,9 +2,9 @@ import type { SQSBatchResponse, SQSEvent } from 'aws-lambda'
 import middy from '@middy/core'
 import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware'
 import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware'
-import * as awsSfn from './common/awssfn'
-import { getLogger, getTracer } from './common/powertools'
-import { getEnvironment } from './common/get_environment'
+import * as awsSfn from './common/awssfn.js'
+import { getLogger, getTracer } from './common/powertools.js'
+import { getEnvironment } from './common/get_environment.js'
 
 const logger = getLogger('INFO')
 const tracer = getTracer()

--- a/lib/api_function.ts
+++ b/lib/api_function.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as ssm from 'aws-cdk-lib/aws-ssm'
-import { LambdaFunction } from './lamda_function'
+import { LambdaFunction } from './lamda_function.js'
 
 interface ApiFunctionProps {
   readonly stackName: string;

--- a/lib/get_dayraces_urls_statemachine.ts
+++ b/lib/get_dayraces_urls_statemachine.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib'
 import * as sqs from 'aws-cdk-lib/aws-sqs'
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions'
 import * as sfnTasks from 'aws-cdk-lib/aws-stepfunctions-tasks'
-import { LambdaFunction } from './lamda_function'
+import { LambdaFunction } from './lamda_function.js'
 
 interface GetDayRacesUrlsStateMachineProps {
   readonly stackName: string;

--- a/lib/get_race_urls_statemachine.ts
+++ b/lib/get_race_urls_statemachine.ts
@@ -4,7 +4,7 @@ import * as logs from 'aws-cdk-lib/aws-logs'
 import * as sqs from 'aws-cdk-lib/aws-sqs'
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions'
 import * as sfnTasks from 'aws-cdk-lib/aws-stepfunctions-tasks'
-import { LambdaFunction } from './lamda_function'
+import { LambdaFunction } from './lamda_function.js'
 
 interface GetRaceUrlsStateMachineProps {
   readonly stackName: string;

--- a/lib/nar_api-stack.ts
+++ b/lib/nar_api-stack.ts
@@ -1,11 +1,11 @@
 import * as cdk from 'aws-cdk-lib'
 import { Construct } from 'constructs'
-import { StateMachineScheduler } from './statemachine_scheduler'
-import { GetDayRacesUrlsStateMachine } from './get_dayraces_urls_statemachine'
-import { GetRaceUrlsStateMachine } from './get_race_urls_statemachine'
-import { QueueToStateMachine } from './queue_to_statemachine'
-import { RaceQueue } from './race_queue'
-import { ApiFunction } from './api_function'
+import { StateMachineScheduler } from './statemachine_scheduler.js'
+import { GetDayRacesUrlsStateMachine } from './get_dayraces_urls_statemachine.js'
+import { GetRaceUrlsStateMachine } from './get_race_urls_statemachine.js'
+import { QueueToStateMachine } from './queue_to_statemachine.js'
+import { RaceQueue } from './race_queue.js'
+import { ApiFunction } from './api_function.js'
 
 interface NarApiStackProps extends cdk.StackProps {
   stage: string;

--- a/lib/queue_to_statemachine.ts
+++ b/lib/queue_to_statemachine.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib'
 import * as eventSource from 'aws-cdk-lib/aws-lambda-event-sources'
 import * as sqs from 'aws-cdk-lib/aws-sqs'
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions'
-import { LambdaFunction } from './lamda_function'
+import { LambdaFunction } from './lamda_function.js'
 
 interface QueueToStateMachineProps {
   readonly stackName: string;

--- a/lib/race_queue.ts
+++ b/lib/race_queue.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib'
 import * as eventSource from 'aws-cdk-lib/aws-lambda-event-sources'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as sqs from 'aws-cdk-lib/aws-sqs'
-import { LambdaFunction } from './lamda_function'
+import { LambdaFunction } from './lamda_function.js'
 
 interface RaceQueueProps {
   readonly stackName: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,13 @@
         "@aws-sdk/client-sfn": "^3.1057.0",
         "@aws-sdk/lib-storage": "^3.1057.0",
         "@codegenie/serverless-express": "^5.0.0",
-        "@middy/core": "^4.0.0",
+        "@middy/core": "^7.6.5",
         "aws-cdk-lib": "^2.257.0",
         "axios": "^1.16.1",
         "cheerio": "^1.0.0-rc.12",
         "constructs": "^10.6.0",
         "express": "^5.2.1",
-        "luxon": "^3.7.2",
-        "source-map-support": "^0.5.21"
+        "luxon": "^3.7.2"
       },
       "bin": {
         "nar_api": "bin/nar_api.js"
@@ -1545,11 +1544,36 @@
       }
     },
     "node_modules/@middy/core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.7.0.tgz",
-      "integrity": "sha512-yI++DmhDQ8+ugvY7+GrEnb2PF0M/6Wzbgu4Tf7QhOlhwKGDd4j6or+Ab7qYPWx+jnKf8F0tqlmh0gV4JLi0yHw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-7.6.5.tgz",
+      "integrity": "sha512-z+jrr1VSMe2I7tkG0EvdezQFTl2ad90NxozfLCs4WimF066YjwnLSj4zZY8swaFw6SWQcTm5R0KcNCXeAhti2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@middy/util": "7.6.5"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
+      },
+      "peerDependencies": {
+        "@aws/durable-execution-sdk-js": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws/durable-execution-sdk-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@middy/util": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-7.6.5.tgz",
+      "integrity": "sha512-xXx5SmKfs6TK6P9jvUVBxnYq743LI3Gv7St/ITswtSjKMvuUHvbS30RMM+tbN6tC+8e4l6Gt/iyiz20C9/PyXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       },
       "funding": {
         "type": "github",
@@ -3967,11 +3991,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -8175,14 +8194,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8191,15 +8202,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nar_api",
   "version": "0.1.0",
+  "type": "module",
   "packageManager": "npm@11.11.0",
   "engines": {
     "node": ">=24.0.0",
@@ -14,13 +15,13 @@
     "watch": "tsc -w",
     "test": "TZ=UTC vitest run",
     "cdk": "cdk",
-    "synth": "cdk synth",
-    "deploy": "cdk deploy --require-approval never",
+    "synth": "npm run compile && cdk synth",
+    "deploy": "npm run compile && cdk deploy --require-approval never",
     "lint": "eslint .",
     "compile": "tsc",
     "fix": "eslint . --fix",
     "_prepare": "npm run compile",
-    "pretest": "npm run compile && npm run synth > /dev/null",
+    "pretest": "npm run synth > /dev/null",
     "posttest": "npm run lint"
   },
   "devDependencies": {
@@ -51,13 +52,12 @@
     "@aws-sdk/client-sfn": "^3.1057.0",
     "@aws-sdk/lib-storage": "^3.1057.0",
     "@codegenie/serverless-express": "^5.0.0",
-    "@middy/core": "^4.0.0",
+    "@middy/core": "^7.6.5",
     "aws-cdk-lib": "^2.257.0",
     "axios": "^1.16.1",
     "cheerio": "^1.0.0-rc.12",
     "constructs": "^10.6.0",
     "express": "^5.2.1",
-    "luxon": "^3.7.2",
-    "source-map-support": "^0.5.21"
+    "luxon": "^3.7.2"
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
-import app from './functions/api'
-import * as Log from './functions/common/log'
+import app from './functions/api.js'
+import * as Log from './functions/common/log.js'
 
 Log.initialize({
   logger: console,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -3,14 +3,14 @@ import request from 'supertest'
 import app, {
   handleGetRaceRequest,
   raceidRouteParamIsString,
-} from '../functions/api'
-import { getRaceIds } from '../functions/api_get_raceids'
-import { getRace } from '../functions/api_get_race'
+} from '../functions/api.js'
+import { getRaceIds } from '../functions/api_get_raceids.js'
+import { getRace } from '../functions/api_get_race.js'
 
 vitest.mock('@aws-lambda-powertools/logger')
 vitest.mock('@aws-lambda-powertools/tracer')
-vitest.mock('../functions/api_get_raceids')
-vitest.mock('../functions/api_get_race')
+vitest.mock('../functions/api_get_raceids.js')
+vitest.mock('../functions/api_get_race.js')
 
 const mockGetRaceIds = vitest.mocked(getRaceIds)
 const mockGetRace = vitest.mocked(getRace)

--- a/test/api_get_race.test.ts
+++ b/test/api_get_race.test.ts
@@ -1,13 +1,13 @@
 import { gzipSync } from 'node:zlib'
-import { getRace } from '../functions/api_get_race'
-import { getEnvironment } from '../functions/common/get_environment'
-import { getRaceDatePrefix } from '../functions/common/get_race_date_prefix'
-import { getObject as S3GetObject } from '../functions/common/awss3'
+import { getRace } from '../functions/api_get_race.js'
+import { getEnvironment } from '../functions/common/get_environment.js'
+import { getRaceDatePrefix } from '../functions/common/get_race_date_prefix.js'
+import { getObject as S3GetObject } from '../functions/common/awss3.js'
 import { Readable } from 'node:stream'
 
-vitest.mock('../functions/common/get_environment')
-vitest.mock('../functions/common/get_race_date_prefix')
-vitest.mock('../functions/common/awss3')
+vitest.mock('../functions/common/get_environment.js')
+vitest.mock('../functions/common/get_race_date_prefix.js')
+vitest.mock('../functions/common/awss3.js')
 
 const getEnvironmentMock = vitest.mocked(getEnvironment)
 const getRaceDatePrefixMock = vitest.mocked(getRaceDatePrefix)

--- a/test/api_get_raceids.test.ts
+++ b/test/api_get_raceids.test.ts
@@ -1,12 +1,12 @@
 import { DateTime } from 'luxon'
-import { getRaceIds } from '../functions/api_get_raceids'
-import { listObjects } from '../functions/common/awss3'
-import { getEnvironment } from '../functions/common/get_environment'
-import { getRaceDatePrefix } from '../functions/common/get_race_date_prefix'
+import { getRaceIds } from '../functions/api_get_raceids.js'
+import { listObjects } from '../functions/common/awss3.js'
+import { getEnvironment } from '../functions/common/get_environment.js'
+import { getRaceDatePrefix } from '../functions/common/get_race_date_prefix.js'
 
-vitest.mock('../functions/common/awss3')
-vitest.mock('../functions/common/get_environment')
-vitest.mock('../functions/common/get_race_date_prefix')
+vitest.mock('../functions/common/awss3.js')
+vitest.mock('../functions/common/get_environment.js')
+vitest.mock('../functions/common/get_race_date_prefix.js')
 
 const listObjectsMock = vitest.mocked(listObjects)
 const getEnvironmentMock = vitest.mocked(getEnvironment)

--- a/test/awss3.test.ts
+++ b/test/awss3.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@aws-sdk/client-s3'
 import { sdkStreamMixin } from '@smithy/util-stream'
 import { mockClient } from 'aws-sdk-client-mock'
-import { listObjects, getObject, upload } from '../functions/common/awss3'
+import { listObjects, getObject, upload } from '../functions/common/awss3.js'
 import { Upload } from '@aws-sdk/lib-storage'
 
 const s3Mock = mockClient(S3Client)

--- a/test/awssfn.test.ts
+++ b/test/awssfn.test.ts
@@ -1,6 +1,6 @@
 import { SFNClient, StartSyncExecutionCommand } from '@aws-sdk/client-sfn'
 import { mockClient } from 'aws-sdk-client-mock'
-import { startSyncExecution } from '../functions/common/awssfn'
+import { startSyncExecution } from '../functions/common/awssfn.js'
 
 const sfnMock = mockClient(SFNClient)
 

--- a/test/get_dayraces_urls.test.ts
+++ b/test/get_dayraces_urls.test.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'aws-lambda'
 import axios from 'axios'
-import { handler } from '../functions/get_dayraces_urls'
+import { handler } from '../functions/get_dayraces_urls.js'
 
 vitest.mock('axios')
 vitest.mock('@aws-lambda-powertools/logger')

--- a/test/get_environment.test.ts
+++ b/test/get_environment.test.ts
@@ -1,4 +1,4 @@
-import { getEnvironment } from '../functions/common/get_environment'
+import { getEnvironment } from '../functions/common/get_environment.js'
 
 let env: NodeJS.ProcessEnv
 

--- a/test/get_race.test.ts
+++ b/test/get_race.test.ts
@@ -1,13 +1,13 @@
 import { Readable } from 'node:stream'
 import axios from 'axios'
 import type { Context, SQSRecord } from 'aws-lambda'
-import { upload } from '../functions/common/awss3'
-import { handler } from '../functions/get_race'
+import { upload } from '../functions/common/awss3.js'
+import { handler } from '../functions/get_race.js'
 
 vitest.mock('axios')
 vitest.mock('@aws-lambda-powertools/logger')
 vitest.mock('@aws-lambda-powertools/tracer')
-vitest.mock('../functions/common/get_environment', () => ({
+vitest.mock('../functions/common/get_environment.js', () => ({
   getEnvironment: (name: string) => {
     if (name === 'CACHE_BUCKET') {
       return 'CACHE_BUCKET_VALUE'
@@ -18,7 +18,7 @@ vitest.mock('../functions/common/get_environment', () => ({
     throw new Error(`unexpected name: ${name}`)
   },
 }))
-vitest.mock('../functions/common/awss3')
+vitest.mock('../functions/common/awss3.js')
 
 const mockAxiosGet = vitest.spyOn(axios, 'get')
 const mockUpload = vitest.mocked(upload)

--- a/test/get_race_urls.test.ts
+++ b/test/get_race_urls.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import type { Context } from 'aws-lambda'
-import { handler } from '../functions/get_race_urls'
+import { handler } from '../functions/get_race_urls.js'
 
 vitest.mock('axios')
 vitest.mock('@aws-lambda-powertools/logger')

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,4 +1,4 @@
-import * as Log from '../functions/common/log'
+import * as Log from '../functions/common/log.js'
 
 describe('log', () => {
   beforeEach(() => {

--- a/test/nar_api.test.ts
+++ b/test/nar_api.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { Template } from 'aws-cdk-lib/assertions'
 import * as cdk from 'aws-cdk-lib'
-import { NarApiStack } from '../lib/nar_api-stack'
+import { NarApiStack } from '../lib/nar_api-stack.js'
 
 const functionNames: readonly string[] = [
   'GetDayRacesUrlsFunction',

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib'
 import { Template } from 'aws-cdk-lib/assertions'
-import { NarApiStack } from '../lib/nar_api-stack'
+import { NarApiStack } from '../lib/nar_api-stack.js'
 
 const ignoreAssetHashSerializer = {
   test: (val: unknown) => typeof val === 'string',

--- a/test/sqs_to_statemachine.test.ts
+++ b/test/sqs_to_statemachine.test.ts
@@ -1,10 +1,10 @@
 import type { Context, SQSBatchResponse, SQSRecord } from 'aws-lambda'
-import { startSyncExecution } from '../functions/common/awssfn'
-import { handler } from '../functions/sqs_to_statemachine'
+import { startSyncExecution } from '../functions/common/awssfn.js'
+import { handler } from '../functions/sqs_to_statemachine.js'
 
 vitest.mock('@aws-lambda-powertools/logger')
 vitest.mock('@aws-lambda-powertools/tracer')
-vitest.mock('../functions/common/get_environment', () => ({
+vitest.mock('../functions/common/get_environment.js', () => ({
   getEnvironment: (name: string) => {
     if (name === 'STATE_MACHINE_ARN') {
       return 'STATE_MACHINE_ARN_VALUE'
@@ -12,7 +12,7 @@ vitest.mock('../functions/common/get_environment', () => ({
     throw new Error(`unexpected name: ${name}`)
   },
 }))
-vitest.mock('../functions/common/awssfn')
+vitest.mock('../functions/common/awssfn.js')
 
 const mockStartSyncExecution = vitest.mocked(startSyncExecution)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "rootDir": ".",
     "outDir": "build",
     "esModuleInterop": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": [
     "lib/**/*.ts",


### PR DESCRIPTION
## Summary

- `@middy/core` を 4.7.0 から 7.6.5 に更新し、ESM 専用化に伴うプロジェクト全体の ESM 移行を実施
- `package.json` に `"type": "module"` を追加し、`tsconfig.json` を `NodeNext` に設定
- 相対 import / `vitest.mock()` に `.js` 拡張子を付与
- CDK エントリをコンパイル済み JS（`node --enable-source-maps build/bin/nar_api.js`）に変更
- 不要になった `source-map-support` 依存を削除

## Test plan

- [x] `npm run compile` が成功すること
- [x] `npm run test`（synth / vitest / lint 含む）が成功すること
- [ ] CI `build-and-deploy` が成功すること


Made with [Cursor](https://cursor.com)