### PR TITLE
Dependabot の依存関係グループ設定を拡張する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,34 @@ updates:
       semver-minor-days: 1
       semver-patch-days: 1
     groups:
+      aws-cdk:
+        patterns:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+          - "constructs"
+          - "@aws-cdk/*"
       aws-lambda-powertools:
         patterns:
           - "@aws-lambda-powertools/*"
       aws-sdk:
         patterns:
           - "@aws-sdk/*"
+          - "@smithy/*"
+          - "aws-sdk-client-mock"
+          - "aws-sdk-client-mock-vitest"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "neostandard"
+      types:
+        patterns:
+          - "@types/*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@tsconfig/*"


### PR DESCRIPTION
## Summary
- `aws-cdk` グループを新設し、`aws-cdk`・`aws-cdk-lib`・`constructs`・`@aws-cdk/*` を同一 PR で更新するようにした
- 既存の `aws-sdk` グループに `@smithy/*`・`aws-sdk-client-mock`・`aws-sdk-client-mock-vitest` を追加した
- `vitest`・`eslint`・`types`・`typescript` グループを追加し、開発ツール系の更新 PR を整理した

## Test plan
- [ ] `.github/dependabot.yml` の YAML 構文が正しいことを確認する
- [ ] マージ後、次回の Dependabot 実行でグループ単位の PR が生成されることを確認する


Made with [Cursor](https://cursor.com)