### PR TITLE
fix: vitestのtestTimeoutを10秒に設定

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./test/setup.ts'],
     include: ['test/**/*.test.ts'],
+    testTimeout: 10000,
     coverage: {
       provider: 'v8',
       enabled: true,


### PR DESCRIPTION
## Summary
- [PR #152](https://github.com/masaminh/nar_api/pull/152)(依存パッケージのバージョン更新のみ)のCIが`test/snapshot.test.ts`のタイムアウトで失敗していた原因を調査
- `test/snapshot.test.ts`はCDK synth相当の重いesbuildバンドル処理を含み安定して5秒前後かかるが、vitestのデフォルトタイムアウト(5000ms)ぎりぎりでCI環境の速度差により間欠的に失敗していた
- 依存関係の変更を伴わない`main`ブランチへのpushでも同じ失敗が発生していたことを確認しており、PR #152自体の変更が原因ではなく既存のテストが持つタイミング起因のフレーキーさだった
- 兄弟リポジトリ`ses_to_slack`/`notify_school`では既に`testTimeout: 10000`を設定して同じ問題を回避しているため、同様の設定を追加

## Test plan
- [x] ローカルで`npm test`を実行し、48テスト全て成功することを確認
- [ ] マージ後、`main`の`build-and-deploy`CIが成功することを確認
- [ ] PR #152のCIも再実行(ブランチ更新後)で成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)